### PR TITLE
Fix : 유저 프로필 조회 API

### DIFF
--- a/HalfFifty_BE/src/main/java/HalfFifty/HalfFifty_BE/user/bean/small/CreateUserDTOBean.java
+++ b/HalfFifty_BE/src/main/java/HalfFifty/HalfFifty_BE/user/bean/small/CreateUserDTOBean.java
@@ -12,6 +12,7 @@ public class CreateUserDTOBean {
                 .userId(userDAO.getUserId())
                 .nickname(userDAO.getNickName())
                 .phoneNumber(userDAO.getPhoneNumber())
+                .username(userDAO.getUsername())
                 .createdAt(userDAO.getCreatedAt())
                 .build();
     }

--- a/HalfFifty_BE/src/main/java/HalfFifty/HalfFifty_BE/user/domain/DTO/ResponseUserGetDTO.java
+++ b/HalfFifty_BE/src/main/java/HalfFifty/HalfFifty_BE/user/domain/DTO/ResponseUserGetDTO.java
@@ -12,5 +12,6 @@ public class ResponseUserGetDTO {
     UUID userId;
     String nickname;
     String phoneNumber;
+    String username;
     LocalDateTime createdAt;
 }


### PR DESCRIPTION
## 🔘 Part
- [x] BE

  
## ⚒️ 작업 내용
- 유저 프로필 조회 API에 username 필드 반환값 추가

## 📷 이미지
<img width="344" alt="image" src="https://github.com/user-attachments/assets/3d4710ec-c115-45db-b929-77d342640c80" />

## ✔️ 체크 리스트
- [x] 수정된 API에 정보가 잘 나타나는가
