### PR TITLE
Refator: 다수결 스무딩을 적용한 수화 인식 API에 맞춰 전송 형태 변경

### DIFF
--- a/HalfFifty_FE/HalfFifty_FE/View/MainView.swift
+++ b/HalfFifty_FE/HalfFifty_FE/View/MainView.swift
@@ -17,6 +17,8 @@ struct MainView: View {
     @State var useMicrophone: Bool = false // 음성 입력 사용 여부
     @State private var cameraFrame: CGRect = .zero // 카메라 크기 저장
     @State private var translationResultList: [String] = [] // 번역 결과 리스트
+    @State private var recStatus: RecognitionStatus = .idle
+    @State private var showStatusBanner: Bool = false
 
     var body: some View {
         GeometryReader { geometry in
@@ -201,6 +203,40 @@ struct MainView: View {
                                 .padding(.bottom, 20)
                             }
                         }
+                        
+                        if showStatusBanner {
+                            VStack {
+                                HStack(spacing: 8) {
+                                    switch recStatus {
+                                    case .processing(let cur, let tot, let msg):
+                                        ProgressView().progressViewStyle(CircularProgressViewStyle())
+                                        Text("\(msg)  \(cur)/\(tot)")
+                                            .font(.system(size: 14, weight: .semibold))
+                                    case .failed(let message):
+                                        Image(systemName: "exclamationmark.triangle.fill")
+                                        Text(message)
+                                            .font(.system(size: 14, weight: .semibold))
+                                    case .success(let word, let prob):
+                                        Image(systemName: "checkmark.circle.fill")
+                                        Text("인식: \(word) (\(Int(prob*100))%)")
+                                            .font(.system(size: 14, weight: .semibold))
+                                    case .idle:
+                                        EmptyView()
+                                    }
+                                    Spacer(minLength: 0)
+                                }
+                                .foregroundColor(.white)
+                                .padding(.vertical, 10)
+                                .padding(.horizontal, 12)
+                                .background(Color.black.opacity(0.6))
+                                .cornerRadius(12)
+                                .padding(.top, 12)
+
+                                Spacer()
+                            }
+                            .transition(.move(edge: .top).combined(with: .opacity))
+                            .animation(.easeInOut(duration: 0.2), value: showStatusBanner)
+                        }
                     }
                     .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: geometry.size.height / 1.7)
                     .background(Color.black)
@@ -245,6 +281,44 @@ struct MainView: View {
                 }
             }
         }
+        // 진행 중
+        .onReceive(NotificationCenter.default.publisher(for: .TranslationProgress)) { note in
+            let cur = note.userInfo?["current"] as? Int ?? 0
+            let tot = note.userInfo?["total"] as? Int ?? 5
+            let msg = note.userInfo?["message"] as? String ?? "수화 인식 중..."
+            self.recStatus = .processing(current: cur, total: tot, message: msg)
+            withAnimation { self.showStatusBanner = true }
+        }
+        // 실패
+        .onReceive(NotificationCenter.default.publisher(for: .TranslationFailed)) { note in
+            let msg = note.userInfo?["message"] as? String ?? "수화 인식 실패"
+            self.recStatus = .failed(message: msg)
+            withAnimation { self.showStatusBanner = true }
+            // 잠깐 보여주고 숨김
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
+                withAnimation { self.showStatusBanner = false }
+                self.recStatus = .idle
+            }
+        }
+        // 성공
+        .onReceive(NotificationCenter.default.publisher(for: .TranslationSuccess)) { note in
+            let word = note.userInfo?["translatedWord"] as? String ?? ""
+            let prob = note.userInfo?["probability"] as? Float ?? 0
+            self.recStatus = .success(word: word, prob: prob)
+            withAnimation { self.showStatusBanner = true }
+
+            // 칩에 추가 (중복 방지 + 최대 10개 유지)
+            if self.translationResultList.last != word {
+                self.translationResultList.append(word)
+                if self.translationResultList.count > 10 { self.translationResultList.removeFirst() }
+            }
+
+            // 잠깐 보여주고 숨김
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
+                withAnimation { self.showStatusBanner = false }
+                self.recStatus = .idle
+            }
+        }
         .navigationBarBackButtonHidden(true)
         .onAppear {
             checkCameraAuthorizationStatus()
@@ -279,6 +353,13 @@ struct MainView: View {
             UIApplication.shared.open(url)
         }
     }
+}
+
+enum RecognitionStatus: Equatable {
+    case idle
+    case processing(current: Int, total: Int, message: String)
+    case failed(message: String)
+    case success(word: String, prob: Float)
 }
 
 #Preview {

--- a/HalfFifty_FE/HalfFifty_FE/View/MainView.swift
+++ b/HalfFifty_FE/HalfFifty_FE/View/MainView.swift
@@ -208,9 +208,9 @@ struct MainView: View {
                             VStack {
                                 HStack(spacing: 8) {
                                     switch recStatus {
-                                    case .processing(let cur, let tot, let msg):
+                                    case .processing(_, _, let msg):
                                         ProgressView().progressViewStyle(CircularProgressViewStyle())
-                                        Text("\(msg)  \(cur)/\(tot)")
+                                        Text("\(msg)")
                                             .font(.system(size: 14, weight: .semibold))
                                     case .failed(let message):
                                         Image(systemName: "exclamationmark.triangle.fill")
@@ -283,10 +283,12 @@ struct MainView: View {
         }
         // 진행 중
         .onReceive(NotificationCenter.default.publisher(for: .TranslationProgress)) { note in
-            let cur = note.userInfo?["current"] as? Int ?? 0
-            let tot = note.userInfo?["total"] as? Int ?? 5
             let msg = note.userInfo?["message"] as? String ?? "수화 인식 중..."
-            self.recStatus = .processing(current: cur, total: tot, message: msg)
+            self.recStatus = .processing(
+                current: note.userInfo?["current"] as? Int ?? 0,
+                total: note.userInfo?["total"] as? Int ?? 5,
+                message: msg
+            )
             withAnimation { self.showStatusBanner = true }
         }
         // 실패

--- a/HalfFifty_FE/HalfFifty_FE/ViewController/CameraViewController.swift
+++ b/HalfFifty_FE/HalfFifty_FE/ViewController/CameraViewController.swift
@@ -10,6 +10,8 @@ import AVFoundation
 import MediaPipeTasksVision
 
 class CameraViewController: UIViewController {
+    var userVM: UserViewModel?
+    
     var isFrontCamera: Bool = false
     var cameraFrame: CGRect = .zero
     private var captureSession: AVCaptureSession!
@@ -19,21 +21,28 @@ class CameraViewController: UIViewController {
     private var videoInput: AVCaptureDeviceInput!
     private var videoOutput: AVCaptureVideoDataOutput!
     
-    private let overlayView = UIImageView() // 랜드마크 및 연결선 표시용 레이어
+    private let overlayView = UIImageView()
     private let maxFrames = 30
     private var keypointsBuffer: [[[[Double]]]] = []
-    private let minimumHandConfidence: Float = 0.8 // 손 인식 확신 기준
+    private let minimumHandConfidence: Float = 0.5
+    private var lastAppendTimeMS: Int? = nil
+    private let maxGapMS: Int = 1200
     
-    private var requestQueue: [[[ [ [Double] ] ]]] = [] // 요청 대기열
-    private var isRequesting: Bool = false // 요청 중 여부
+    private var requestQueue: [[[[[Double]]]]] = []
+    private var isRequesting: Bool = false
     
-    // Overlay 캘리브레이션
-    private var overlayScaleX: CGFloat = 0.92   // 가로 폭 줄이기
-    private var overlayScaleY: CGFloat = 2.0   // 세로 높이 늘리기
-
-    // 미세 위치 보정 (픽셀 단위, 우/하 이동)
+    // Overlay calibration
+    private var overlayScaleX: CGFloat = 0.92
+    private var overlayScaleY: CGFloat = 2.0
     private var overlayShiftX: CGFloat = 0.0
     private var overlayShiftY: CGFloat = 80.0
+    
+    private var progressStep = 0
+    private let totalSteps = 5
+    
+    private var userId: String {
+        userVM?.userId ?? "5cbd5b33-833f-430a-97f3-96706b12ce71"
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -63,16 +72,17 @@ class CameraViewController: UIViewController {
     private func setupOverlayView() {
         overlayView.frame = view.bounds
         overlayView.contentMode = .scaleAspectFill
+        overlayView.isUserInteractionEnabled = false
+        overlayView.backgroundColor = .clear
         view.addSubview(overlayView)
+        view.bringSubviewToFront(overlayView)
     }
     
     private func setupVideoOutput() {
         videoOutput = AVCaptureVideoDataOutput()
-        
         videoOutput.videoSettings = [
             kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA
         ]
-        
         videoOutput.setSampleBufferDelegate(self, queue: DispatchQueue(label: "videoQueue"))
         if captureSession.canAddOutput(videoOutput) {
             captureSession.addOutput(videoOutput)
@@ -86,7 +96,6 @@ class CameraViewController: UIViewController {
     
     private func switchCamera(toFront: Bool) {
         captureSession.beginConfiguration()
-        
         if let currentInput = captureSession.inputs.first {
             captureSession.removeInput(currentInput)
         }
@@ -101,31 +110,26 @@ class CameraViewController: UIViewController {
                     videoInput = newInput
                 }
             } catch {
-                print("카메라 전환 오류: \(error)")
+                // handle error if needed
             }
         }
-        
         captureSession.commitConfiguration()
     }
     
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         videoPreviewLayer.frame = view.bounds
-        
-        // 오버레이 뷰 비율 유지하면서 크기 조정
+
+        let overlayImageSize = overlayView.image?.size ?? CGSize(width: 1, height: 1)
         let cameraAspectRatio = videoPreviewLayer.bounds.width / videoPreviewLayer.bounds.height
-        let overlayAspectRatio = overlayView.image?.size.width ?? 1.0 / (overlayView.image?.size.height ?? 1.0)
-        
+        let overlayAspectRatio = overlayImageSize.width / overlayImageSize.height
+
         var newOverlayFrame = videoPreviewLayer.bounds
-        
         if cameraAspectRatio > overlayAspectRatio {
-            // 카메라가 더 넓을 경우 → 높이를 기준으로 조정
             newOverlayFrame.size.width = newOverlayFrame.height * overlayAspectRatio
         } else {
-            // 카메라가 더 좁을 경우 → 너비를 기준으로 조정
             newOverlayFrame.size.height = newOverlayFrame.width / overlayAspectRatio
         }
-        
         overlayView.frame = newOverlayFrame
         overlayView.center = videoPreviewLayer.position
     }
@@ -138,7 +142,6 @@ class CameraViewController: UIViewController {
     // Mediapipe HandLandmarker 초기화
     private func setupHandLandmarker() {
         guard let modelPath = Bundle.main.path(forResource: "hand_landmarker", ofType: "task") else {
-            print("hand_landmarker.task 모델을 찾을 수 없습니다.")
             return
         }
         
@@ -151,10 +154,9 @@ class CameraViewController: UIViewController {
             options.minHandPresenceConfidence = 0.5
             options.minTrackingConfidence = 0.5
             options.handLandmarkerLiveStreamDelegate = self
-            
             handLandmarker = try HandLandmarker(options: options)
         } catch {
-            print("HandLandmarker 초기화 중 에러 발생: \(error.localizedDescription)")
+            // handle error if needed
         }
     }
     
@@ -164,19 +166,13 @@ class CameraViewController: UIViewController {
         
         let format = CVPixelBufferGetPixelFormatType(pixelBuffer)
         if format != kCVPixelFormatType_32BGRA {
-            print("Unsupported pixel format detected: \(format). Converting to kCVPixelFormatType_32BGRA.")
-            guard let convertedBuffer = convertPixelBufferToBGRA(pixelBuffer) else {
-                print("픽셀 버퍼 변환 실패")
-                return
-            }
+            guard let convertedBuffer = convertPixelBufferToBGRA(pixelBuffer) else { return }
             processValidFrame(convertedBuffer, timestamp: timestamp)
             return
         }
-        
         processValidFrame(pixelBuffer, timestamp: timestamp)
     }
     
-    // `kCVPixelFormatType_32BGRA`로 변환하는 함수 추가
     private func convertPixelBufferToBGRA(_ pixelBuffer: CVPixelBuffer) -> CVPixelBuffer? {
         let width = CVPixelBufferGetWidth(pixelBuffer)
         let height = CVPixelBufferGetHeight(pixelBuffer)
@@ -199,7 +195,6 @@ class CameraViewController: UIViewController {
             return nil
         }
         
-        // 변환된 픽셀 버퍼에 원본 데이터 복사
         CVPixelBufferLockBaseAddress(pixelBuffer, .readOnly)
         CVPixelBufferLockBaseAddress(outputBuffer, [])
         
@@ -214,13 +209,12 @@ class CameraViewController: UIViewController {
         return outputBuffer
     }
     
-    // 변환된 프레임을 처리하는 함수
     private func processValidFrame(_ pixelBuffer: CVPixelBuffer, timestamp: Int) {
         do {
             let mpImage = try MPImage(pixelBuffer: pixelBuffer)
             try handLandmarker.detectAsync(image: mpImage, timestampInMilliseconds: timestamp)
         } catch {
-            print("프레임 처리 중 에러 발생: \(error.localizedDescription)")
+            // handle error if needed
         }
     }
     
@@ -228,37 +222,35 @@ class CameraViewController: UIViewController {
     private func drawHandLandmarks(_ result: HandLandmarkerResult) {
         let cameraResolution = videoPreviewLayer.bounds.size
         let overlayResolution = overlayView.bounds.size
-        if cameraResolution.width == 0 || cameraResolution.height == 0 { return }
 
-        UIGraphicsBeginImageContext(overlayResolution)
+        guard overlayResolution.width.isFinite, overlayResolution.height.isFinite,
+              overlayResolution.width > 0, overlayResolution.height > 0 else { return }
+        guard cameraResolution.width > 0, cameraResolution.height > 0 else { return }
+
+        UIGraphicsBeginImageContextWithOptions(overlayResolution, false, 0)
         guard let context = UIGraphicsGetCurrentContext() else { return }
         context.clear(CGRect(origin: .zero, size: overlayResolution))
         context.setStrokeColor(UIColor.green.cgColor)
         context.setLineWidth(2.0)
 
-        // 캘리브레이션 중심(중앙 기준으로 스케일링해야 왜곡이 안 생김)
         let cx = overlayResolution.width  * 0.5
         let cy = overlayResolution.height * 0.5
 
-        // 비율 보정 계산(기존 코드 유지)
         let scaleX = overlayResolution.width  / cameraResolution.width
         let scaleY = overlayResolution.height / cameraResolution.height
         let minScale = min(scaleX, scaleY)
 
         for hand in result.landmarks {
             var points: [CGPoint] = []
-
             for landmark in hand {
                 var x = CGFloat(landmark.x) * cameraResolution.width  * minScale
                 var y = (1 - CGFloat(landmark.y)) * cameraResolution.height * minScale
 
                 if isFrontCamera {
-                    // 전면: 90° 오른쪽 회전 (기존 로직 유지)
                     let tempX = x
                     x = overlayResolution.width - y
                     y = tempX
                 } else {
-                    // 후면: 90° 왼쪽 회전 + Y축 반전 (기존 로직 유지)
                     let tempX = x
                     x = y
                     y = overlayResolution.height - tempX
@@ -270,13 +262,11 @@ class CameraViewController: UIViewController {
 
                 points.append(CGPoint(x: x, y: y))
 
-                // 점 찍기
                 let circleRect = CGRect(x: x - 3, y: y - 3, width: 6, height: 6)
                 context.setFillColor(UIColor.red.cgColor)
                 context.fillEllipse(in: circleRect)
             }
 
-            // 연결선
             for (startIndex, endIndex) in HandLandmarker.handConnections {
                 if startIndex < points.count, endIndex < points.count {
                     let start = points[startIndex]
@@ -296,81 +286,69 @@ class CameraViewController: UIViewController {
 // Mediapipe의 손 연결 정의
 extension HandLandmarker {
     static let handConnections = [
-        (0, 1), (1, 2), (2, 3), (3, 4), // 엄지
-        (0, 5), (5, 6), (6, 7), (7, 8), // 검지
-        (0, 9), (9, 10), (10, 11), (11, 12), // 중지
-        (0, 13), (13, 14), (14, 15), (15, 16), // 약지
-        (0, 17), (17, 18), (18, 19), (19, 20),  // 새끼
-        (5, 9), (9, 13), (13, 17) // 손바닥
+        (0, 1), (1, 2), (2, 3), (3, 4),
+        (0, 5), (5, 6), (6, 7), (7, 8),
+        (0, 9), (9, 10), (10, 11), (11, 12),
+        (0, 13), (13, 14), (14, 15), (15, 16),
+        (0, 17), (17, 18), (18, 19), (19, 20),
+        (5, 9), (9, 13), (13, 17)
     ]
 }
 
 // HandLandmarkerLiveStreamDelegate 구현
 extension CameraViewController: HandLandmarkerLiveStreamDelegate {
     func handLandmarker(
-        _ handLandmarker: HandLandmarker,
-        didFinishDetection result: HandLandmarkerResult?,
-        timestampInMilliseconds: Int,
-        error: Error?) {
-        
+      _ handLandmarker: HandLandmarker,
+      didFinishDetection result: HandLandmarkerResult?,
+      timestampInMilliseconds: Int,
+      error: Error?
+    ) {
         guard let result = result else { return }
-        
-        DispatchQueue.main.async {
-            self.drawHandLandmarks(result)
-            
-            if result.landmarks.isEmpty {
-                print("손 인식 안됨 -> 버퍼 초기화")
+        let now = timestampInMilliseconds
+
+        DispatchQueue.main.async { self.drawHandLandmarks(result) }
+
+        if result.landmarks.isEmpty || !self.isHandDetectionConfident(result: result) {
+            if let last = self.lastAppendTimeMS, now - last > self.maxGapMS {
                 self.keypointsBuffer.removeAll()
-                return
+                self.progressStep = 0
             }
-            
-            if !self.isHandDetectionConfident(result: result) {
-                print("손 인식 확신도 낮음 -> 버퍼 초기화")
-                self.keypointsBuffer.removeAll()
-                return
-            }
-            
-            // 모든 인식 결과를 즉시 저장
-            if let keypoints = self.extractKeypoints(from: result) {
-                self.keypointsBuffer.append(keypoints)
-            }
-            
-            if self.keypointsBuffer.count >= self.maxFrames {
-                self.sendTranslationRequest(with: self.keypointsBuffer)
-                self.keypointsBuffer.removeAll()
-            }
+            return
+        }
+
+        if let keypoints = self.extractKeypoints(from: result) {
+            self.keypointsBuffer.append(keypoints)
+            self.lastAppendTimeMS = now
+        }
+
+        if self.keypointsBuffer.count >= self.maxFrames {
+            self.sendTranslationRequest(with: self.keypointsBuffer)
+            self.keypointsBuffer.removeAll()
         }
     }
     
     private func isHandDetectionConfident(result: HandLandmarkerResult) -> Bool {
-        guard !result.handedness.isEmpty else {
-            return false
-        }
-        
+        guard !result.handedness.isEmpty else { return false }
         for handScoreList in result.handedness {
             if let firstScore = handScoreList.first, firstScore.score < minimumHandConfidence {
                 return false
             }
         }
-        
         return true
     }
     
     private func extractKeypoints(from result: HandLandmarkerResult) -> [[[Double]]]? {
         guard !result.landmarks.isEmpty else { return nil }
-        
         var frameKeypoints: [[[Double]]] = [
-            Array(repeating: [0.0, 0.0, 0.0], count: 21), // 왼손
-            Array(repeating: [0.0, 0.0, 0.0], count: 21)  // 오른손
+            Array(repeating: [0.0, 0.0, 0.0], count: 21),
+            Array(repeating: [0.0, 0.0, 0.0], count: 21)
         ]
-        
         for (index, hand) in result.landmarks.enumerated() {
             guard index < 2 else { break }
             for (j, landmark) in hand.enumerated() {
                 frameKeypoints[index][j] = [Double(landmark.x), Double(landmark.y), Double(landmark.z)]
             }
         }
-        
         return frameKeypoints
     }
     
@@ -381,20 +359,22 @@ extension CameraViewController: HandLandmarkerLiveStreamDelegate {
 
     private func processNextRequestIfNeeded() {
         guard !isRequesting, !requestQueue.isEmpty else { return }
-
         isRequesting = true
         let currentKeypoints = requestQueue.removeFirst()
 
         guard let url = URL(string: "http://3.34.3.103/translation") else {
-            print("URL이 잘못되었습니다.")
             isRequesting = false
             return
         }
 
-        let requestBody: [String: Any] = ["keypoints": currentKeypoints]
+        let requestBody: [String: Any] = [
+            "userId": userId,
+            "keypoints": currentKeypoints
+        ]
 
         do {
             let jsonData = try JSONSerialization.data(withJSONObject: requestBody, options: [])
+
             var request = URLRequest(url: url)
             request.httpMethod = "POST"
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -404,48 +384,117 @@ extension CameraViewController: HandLandmarkerLiveStreamDelegate {
                 defer {
                     DispatchQueue.main.async {
                         self.isRequesting = false
-                        self.processNextRequestIfNeeded() // 다음 요청 진행
+                        self.processNextRequestIfNeeded()
                     }
                 }
-
-                if let error = error {
-                    print("네트워크 요청 실패: \(error.localizedDescription)")
-                    return
-                }
-
-                guard let data = data else {
-                    print("응답 데이터가 없습니다.")
-                    return
-                }
-
+                guard error == nil, let data = data else { return }
                 do {
                     let decodedResponse = try JSONDecoder().decode(TranslationResponse.self, from: data)
                     DispatchQueue.main.async {
                         self.showTranslationResult(response: decodedResponse)
                     }
                 } catch {
-                    print("JSON 디코딩 오류: \(error.localizedDescription)")
+                    // handle decode error if needed
                 }
             }.resume()
         } catch {
-            print("JSON 변환 오류: \(error.localizedDescription)")
             isRequesting = false
         }
     }
     
-    // 번역 결과를 UI에 표시하는 함수 추가
     private func showTranslationResult(response: TranslationResponse) {
-        guard let translatedWord = response.translatedWord else {
-            print("번역 실패: 알 수 없는 오류")
-            return
+        let status = (response.status ?? "").lowercased()
+
+        switch status {
+        case "processing":
+            let step = parseStep(response.message)
+            if let cur = step?.current, let tot = step?.total {
+                progressStep = cur
+            } else {
+                progressStep = min(progressStep + 1, totalSteps)
+            }
+            NotificationCenter.default.post(
+                name: .TranslationProgress,
+                object: nil,
+                userInfo: [
+                    "message": response.message ?? "수화 인식 중...",
+                    "current": progressStep,
+                    "total": step?.total ?? totalSteps
+                ]
+            )
+
+        case "failed":
+            progressStep = 0
+            NotificationCenter.default.post(
+                name: .TranslationFailed,
+                object: nil,
+                userInfo: ["message": response.message ?? "수화 인식 실패"]
+            )
+
+        case "success":
+            progressStep = 0
+            NotificationCenter.default.post(
+                name: .TranslationSuccess,
+                object: nil,
+                userInfo: [
+                    "translatedWord": response.translatedWord ?? "",
+                    "probability": response.probability ?? 0
+                ]
+            )
+
+        default:
+            if response.success, let word = response.translatedWord {
+                progressStep = 0
+                NotificationCenter.default.post(
+                    name: .TranslationSuccess,
+                    object: nil,
+                    userInfo: ["translatedWord": word, "probability": response.probability ?? 0]
+                )
+            } else {
+                progressStep = 0
+                NotificationCenter.default.post(
+                    name: .TranslationFailed,
+                    object: nil,
+                    userInfo: ["message": response.message ?? "인식 실패"]
+                )
+            }
         }
-        
-        // 결과를 NotificationCenter로 전달
-        NotificationCenter.default.post(
-            name: Notification.Name("TranslationResult"),
-            object: nil,
-            userInfo: ["translatedWord": translatedWord]
-        )
+    }
+    
+    private func parseStep(_ message: String?) -> (current: Int, total: Int)? {
+        guard let msg = message else { return nil }
+        let pattern = #"\(\s*(\d+)\s*\/\s*(\d+)\s*\)"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
+        guard let m = regex.firstMatch(in: msg, range: NSRange(msg.startIndex..., in: msg)) else { return nil }
+        guard let r1 = Range(m.range(at: 1), in: msg),
+              let r2 = Range(m.range(at: 2), in: msg) else { return nil }
+        return (Int(msg[r1]) ?? 0, Int(msg[r2]) ?? 0)
+    }
+    
+    private func summarizePayload(_ keypoints: [[[[Double]]]]) -> String {
+        let frames = keypoints.count
+        let hands  = keypoints.first?.count ?? 0
+        let points = keypoints.first?.first?.count ?? 0
+        let dims   = keypoints.first?.first?.first?.count ?? 0
+
+        var samples: [String] = []
+        if frames > 0, hands > 0, points > 0, dims > 0 {
+            let f0 = 0, h0 = 0
+            let pCount = min(points, 3)
+            for p in 0..<pCount {
+                let arr = keypoints[f0][h0][p]
+                samples.append("p\(p)=\(arr)")
+            }
+        }
+        return "frames=\(frames), hands/frame=\(hands), points/hand=\(points), dims/point=\(dims), sample(f0,h0): \(samples.joined(separator: ", "))"
+    }
+
+    private func prettySize(_ bytes: Int) -> String {
+        if bytes < 1024 { return "\(bytes) B" }
+        let kb = Double(bytes) / 1024.0
+        if kb < 1024 { return String(format:"%.1f KB", kb) }
+        let mb = kb / 1024.0
+        return String(format:"%.2f MB", mb)
     }
 }
 
@@ -453,6 +502,17 @@ extension CameraViewController: HandLandmarkerLiveStreamDelegate {
 struct TranslationResponse: Codable {
     let success: Bool
     let translatedWord: String?
+    let translationId: String?
+    let probability: Float?
+    let message: String?
+    let status: String?
+}
+
+// 상태 알림
+extension Notification.Name {
+    static let TranslationProgress = Notification.Name("TranslationProgress")
+    static let TranslationFailed   = Notification.Name("TranslationFailed")
+    static let TranslationSuccess  = Notification.Name("TranslationSuccess")
 }
 
 // AVCaptureVideoDataOutputSampleBufferDelegate 구현

--- a/HalfFifty_FE/HalfFifty_FE/ViewController/CameraViewController.swift
+++ b/HalfFifty_FE/HalfFifty_FE/ViewController/CameraViewController.swift
@@ -408,11 +408,7 @@ extension CameraViewController: HandLandmarkerLiveStreamDelegate {
         switch status {
         case "processing":
             let step = parseStep(response.message)
-            if let cur = step?.current, let tot = step?.total {
-                progressStep = cur
-            } else {
-                progressStep = min(progressStep + 1, totalSteps)
-            }
+            
             NotificationCenter.default.post(
                 name: .TranslationProgress,
                 object: nil,


### PR DESCRIPTION
## 🔘 Part
- [x] FE
  
## ⚒️ 작업 내용
- 변경 전 request 형식: keypoint 데이터만 30 프레임 전송
- 변경 후 request 형식: userId와 keypoint 데이터 30 프레임 전송
- 카메라 영역 상단에 수화 인식 진행 상황 및 결과 나타내는 영역 추가
- 백엔드에서 수화 인식 진행 상황을 message로 주면 진행 상황 필드에 데이터 바인딩으로 나타냄
- status에 따라서 결과 표시

## 📷 이미지
<img width="300" alt="image" src="https://github.com/user-attachments/assets/36d0ef7a-a188-443e-9e76-1376a576f013" />

## ✔️ 체크 리스트
- [x] 수화 인식 진행 상황이 잘 뜨는가
